### PR TITLE
OPENAI_API_KEYを持たないユーザーがにわとこを使えないバグ修正

### DIFF
--- a/niwatoko/foundation_model/interpretation/llm/gpt.py
+++ b/niwatoko/foundation_model/interpretation/llm/gpt.py
@@ -7,10 +7,6 @@ load_dotenv()  # .envファイルから環境変数を読み込む
 niwatoko_dir = os.path.dirname(niwatoko.__file__)                        # zoltraakパッケージのディレクトリパスを取得
 with open(f"{niwatoko_dir}/grammar/system.md", "r", encoding = "utf-8") as f:
     system_prompt = f.read()
-client = OpenAI(
-    api_key=os.environ.get("OPENAI_API_KEY")
-)
-
 
 def generate_response(model, prompt, max_tokens, temperature):
     """
@@ -25,6 +21,10 @@ def generate_response(model, prompt, max_tokens, temperature):
     Returns:
         str: 生成された応答テキスト。
     """
+    
+    client = OpenAI(
+        api_key=os.environ.get("OPENAI_API_KEY")
+    )
 
     model = "gpt-4-turbo-2024-04-09"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **リファクタ**
	- レスポンス生成機能内でAPIクライアントの初期化を行うよう変更しました。これにより、セキュリティが向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->